### PR TITLE
Add an easy static api

### DIFF
--- a/src/main/java/com/graywolf336/trailingperspective/TrailingPerspectiveAPI.java
+++ b/src/main/java/com/graywolf336/trailingperspective/TrailingPerspectiveAPI.java
@@ -1,0 +1,27 @@
+package com.graywolf336.trailingperspective;
+
+import com.graywolf336.trailingperspective.interfaces.ITrailerManager;
+
+/**
+ * Contains static api for interacting with the plugin.
+ *
+ * @author graywolf336
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+public class TrailingPerspectiveAPI {
+    private static TrailingPerspectiveMain plugin;
+    
+    protected static void setPlugin(TrailingPerspectiveMain pl) {
+        plugin = pl;
+    }
+    
+    /**
+     * Gets the a valid {@link ITrailerManager} instance.
+     * 
+     * @return {@link ITrailerManager} instance
+     */
+    public static ITrailerManager getTrailerManager() {
+        return plugin.getTrailerManager();
+    }
+}

--- a/src/main/java/com/graywolf336/trailingperspective/TrailingPerspectiveMain.java
+++ b/src/main/java/com/graywolf336/trailingperspective/TrailingPerspectiveMain.java
@@ -20,6 +20,8 @@ public class TrailingPerspectiveMain extends JavaPlugin {
 
     public void onLoad() {
         this.saveDefaultConfig();
+        
+        TrailingPerspectiveAPI.setPlugin(this);
     }
 
     public void onEnable() {


### PR DESCRIPTION
This allows `TrailingPerspectiveAPI.getTrailerManager()` instead of getting an instance of the `TrailingPerspectiveMain` from Bukkit and doing everything related to that.

Thoughts @dawgeth 
